### PR TITLE
Refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
 # ClauCy
 Implementation of the ClausIE information extraction system for python+spacy. 
 
-**Disclaimer**: It is **not** meant to be a 1-1 implementation of the algorithm (which is impossible since SpaCy is used instead of Stanford Dependencies like in the paper) but a clause extraction and text simplification library I have for personal use. Therefore I have done some modifications. First of all, I did some exploration on how to better separate embedded clauses when using SpaCy dependencies. Also, when generating propositions in text, I provide the ability to *inflect* the verbs, so that they are in a somewhat useful text form. This allows me to, for example, process complex sentences such as this:
+**Disclaimer**: This is **not** meant to be a 1-1 implementation of the algorithm 
+(which is impossible since SpaCy is used instead of Stanford Dependencies like in the paper) 
+but a clause extraction and text simplification library I have for personal use. 
 
+I have made some modifications. 
+- I did some exploration on how to better separate embedded clauses when using SpaCy dependencies. 
+- I provide the ability to *inflect* the verbs, so that they are in a somewhat useful text form 
+when generating propositions in text. 
+
+This allows the processing of complex sentences such as this:
 ```
-A cat, hearing that the birds in a certain aviary were ailing dressed himself up as a physician, and, taking his cane and a bag of instruments becoming his profession, went to call on them.
+A cat, hearing that the birds in a certain aviary were ailing dressed himself up as a physician, 
+and, taking his cane and a bag of instruments becoming his profession, went to call on them.
 ```
 
-and get propositions such as these:
+to produce propositions such as these:
 
 ```
 ['The birds were ailing.']

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -297,38 +297,42 @@ class Clause:
         # Remove doubles
         propositions = list(set(propositions))
 
-        # Convert to text if `as_text' is set.
         if as_text:
-            texts = [
-                " ".join(
-                    [
-                        " ".join(
-                            [
-                                str(
-                                    t._.inflect(inflect)
-                                )  # Inflect the verb according to the `inflect` flag
-                                if t.pos_ in ["VERB"]  # If t is a verb
-                                   and "AUX"
-                                   not in [
-                                       tt.pos_ for tt in t.lefts
-                                   ]  # t is not preceded by an auxiliary verb (e.g. `the birds were ailing`)
-                                   and t.dep_ not in ['pcomp']  # t `deamed of becoming a dancer`
-                                   and inflect  # and the `inflect' flag is set
-                                else str(t)
-                                for t in s
-                            ]
-                        )
-                        for s in p
-                    ]
-                )
-                for p in propositions
-            ]
-
-            if capitalize:  # Capitalize and add a full stop.
-                texts = [text.capitalize() + "." for text in texts]
-            return texts
+            return _convert_clauses_to_text(propositions, inflect=inflect, capitalize=capitalize)
 
         return propositions
+
+
+def _convert_clauses_to_text(propositions, inflect, capitalize):
+    texts = [
+        " ".join(
+            [
+                " ".join(
+                    [
+                        str(
+                            t._.inflect(inflect)
+                        )  # Inflect the verb according to the `inflect` flag
+                        if t.pos_ in ["VERB"]  # If t is a verb
+                           and "AUX"
+                           not in [
+                               tt.pos_ for tt in t.lefts
+                           ]  # t is not preceded by an auxiliary verb (e.g. `the birds were ailing`)
+                           and t.dep_ not in ['pcomp']  # t `deamed of becoming a dancer`
+                           and inflect  # and the `inflect' flag is set
+                        else str(t)
+                        for t in s
+                    ]
+                )
+                for s in p
+            ]
+        )
+        for p in propositions
+    ]
+
+    if capitalize:  # Capitalize and add a full stop.
+        texts = [text.capitalize() + "." for text in texts]
+
+    return texts
 
 
 def extract_clauses(span):

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -157,47 +157,76 @@ class Clause:
         )
 
         clause_type = "undefined"
+        # # Original
+        # if not has_verb:
+        #     clause_type = "SVC"
+        #     return clause_type
+        # if all([not has_object, has_complement]):
+        #     clause_type = "SVC"
+        #
+        # if all([not has_object, not has_complement, not has_adverbial]):
+        #     clause_type = "SV"
+        # if all([not has_object, not has_complement, has_adverbial, has_non_ext_copular_verb]):
+        #     clause_type = "SV"
+        #
+        # if all(
+        #         [not has_object, not has_complement, has_adverbial, not has_non_ext_copular_verb, has_ext_copular_verb]
+        # ):
+        #     clause_type = "SVA"
+        # if all(
+        #     [
+        #         not has_object,
+        #         not has_complement,
+        #         has_adverbial,
+        #         not has_non_ext_copular_verb,
+        #         not has_ext_copular_verb,
+        #     ]
+        # ):
+        #     if conservative:
+        #         clause_type = "SVA"
+        #     else:
+        #         clause_type = "SV"
+        #
+        # if all([has_object, has_direct_object, has_indirect_object]):
+        #     clause_type = "SVOO"
+        # if all([has_object, not (has_direct_object and has_indirect_object)]):
+        #     if has_complement:
+        #         clause_type = "SVOC"
+        #     elif not (has_adverbial and has_direct_object):
+        #         clause_type = "SVO"
+        #     elif complex_transitive:
+        #         clause_type = "SVOA"
+        #     else:
+        #         if conservative:
+        #             clause_type = "SVOA"
+        #         else:
+        #             clause_type = "SVO"
 
         if not has_verb:
             clause_type = "SVC"
             return clause_type
-        if all([not has_object, has_complement]):
-            clause_type = "SVC"
-        if all([not has_object, not has_complement, not has_adverbial]):
-            clause_type = "SV"
-        if all([not has_object, not has_complement, has_adverbial, has_non_ext_copular_verb]):
-            clause_type = "SV"
-        if all(
-                [not has_object, not has_complement, has_adverbial, not has_non_ext_copular_verb, has_ext_copular_verb]
-        ):
-            clause_type = "SVA"
-        if all(
-            [
-                not has_object,
-                not has_complement,
-                has_adverbial,
-                not has_non_ext_copular_verb,
-                not has_ext_copular_verb,
-            ]
-        ):
-            if conservative:
+
+        if has_object:
+            if has_direct_object and has_indirect_object:
+                clause_type = "SVOO"
+            elif has_complement:
+                clause_type = "SVOC"
+            elif not has_adverbial or not has_direct_object:
+                clause_type = "SVO"
+            elif complex_transitive or conservative:
+                clause_type = "SVOA"
+            else:
+                clause_type = "SVO"
+        else:
+            if has_complement:
+                clause_type = "SVC"
+            elif not has_adverbial or has_non_ext_copular_verb:
+                clause_type = "SV"
+            elif has_ext_copular_verb or conservative:
                 clause_type = "SVA"
             else:
                 clause_type = "SV"
-        if all([has_object, has_direct_object, has_indirect_object]):
-            clause_type = "SVOO"
-        if all([has_object, not (has_direct_object and has_indirect_object)]):
-            if has_complement:
-                clause_type = "SVOC"
-            elif not (has_adverbial and has_direct_object):
-                clause_type = "SVO"
-            elif complex_transitive:
-                clause_type = "SVOA"
-            else:
-                if conservative:
-                    clause_type = "SVOA"
-                else:
-                    clause_type = "SVO"
+
         return clause_type
 
     def __repr__(self):

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -136,6 +136,9 @@ class Clause:
 
         self.doc = self.subject.doc
 
+        self.type = self._get_clause_type()
+
+    def _get_clause_type(self):
         has_verb = self.verb is not None
         has_complement = self.complement is not None
         has_adverbial = len(self.adverbials) > 0
@@ -153,21 +156,21 @@ class Clause:
                 has_verb and self.verb.root.lemma_ in dictionary["complex_transitive"]
         )
 
-        self.type = "undefined"
+        clause_type = "undefined"
 
         if not has_verb:
-            self.type = "SVC"
-            return
+            clause_type = "SVC"
+            return clause_type
         if all([not has_object, has_complement]):
-            self.type = "SVC"
+            clause_type = "SVC"
         if all([not has_object, not has_complement, not has_adverbial]):
-            self.type = "SV"
+            clause_type = "SV"
         if all([not has_object, not has_complement, has_adverbial, has_non_ext_copular_verb]):
-            self.type = "SV"
+            clause_type = "SV"
         if all(
-            [not has_object, not has_complement, has_adverbial, not has_non_ext_copular_verb, has_ext_copular_verb]
+                [not has_object, not has_complement, has_adverbial, not has_non_ext_copular_verb, has_ext_copular_verb]
         ):
-            self.type = "SVA"
+            clause_type = "SVA"
         if all(
             [
                 not has_object,
@@ -178,23 +181,24 @@ class Clause:
             ]
         ):
             if conservative:
-                self.type = "SVA"
+                clause_type = "SVA"
             else:
-                self.type = "SV"
+                clause_type = "SV"
         if all([has_object, has_direct_object, has_indirect_object]):
-            self.type = "SVOO"
+            clause_type = "SVOO"
         if all([has_object, not (has_direct_object and has_indirect_object)]):
             if has_complement:
-                self.type = "SVOC"
+                clause_type = "SVOC"
             elif not (has_adverbial and has_direct_object):
-                self.type = "SVO"
+                clause_type = "SVO"
             elif complex_transitive:
-                self.type = "SVOA"
+                clause_type = "SVOA"
             else:
                 if conservative:
-                    self.type = "SVOA"
+                    clause_type = "SVOA"
                 else:
-                    self.type = "SVO"
+                    clause_type = "SVO"
+        return clause_type
 
     def __repr__(self):
         return "<{}, {}, {}, {}, {}, {}, {}>".format(

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -421,7 +421,7 @@ def extract_clauses(span):
         # If so, add a new clause of the form:
         # <AE, is, a scientist>
         for c in subject.root.children:
-            if c.dep_ in ["appos"]:
+            if c.dep_ == "appos":
                 comp = extract_span_from_entity(c)
                 clause = Clause(subject=subject, complement=comp)
                 clauses.append(clause)
@@ -429,13 +429,13 @@ def extract_clauses(span):
         # 1.c. find indirect object
         iob = None
         for c in verb.root.children:
-            if c.dep_ in ["dative"]:
+            if c.dep_ == "dative":
                 iob = extract_span_from_entity(c)
 
         # 1.d. find direct object
         dob = None
         for c in verb.root.children:
-            if c.dep_ in ["dobj"]:
+            if c.dep_ == "dobj":
                 dob = extract_span_from_entity(c)
 
         # 1.e. find complements
@@ -511,7 +511,7 @@ def extract_ccs_from_token(token):
     else:
         entities = [Span(token.doc, start=token.i, end=token.i + 1)]
     for c in token.children:
-        if c.dep_ in ["conj"]:
+        if c.dep_ == "conj":
             entities += extract_ccs_from_token(c)
     return entities
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -362,9 +362,7 @@ def _get_verb_matches(span):
 
     return verb_matcher(span)
 
-
-def extract_clauses(span):
-    clauses = []
+def _get_verb_chunks(span):
     matches = _get_verb_matches(span)
 
     # Filter matches (e.g. do not have both "has won" and "won" in verbs)
@@ -372,7 +370,14 @@ def extract_clauses(span):
     for match in [span[start:end] for _, start, end in matches]:
         if match.root not in [vp.root for vp in verb_chunks]:
             verb_chunks.append(match)
+    return verb_chunks
 
+
+def extract_clauses(span):
+    clauses = []
+    matches = _get_verb_matches(span)
+
+    verb_chunks = _get_verb_chunks(span)
     for verb in verb_chunks:
         # 1.b. find `subject` for verb
         subject = None

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -99,7 +99,7 @@ class Clause:
         indirect_object: t.Optional[Span] = None,
         direct_object: t.Optional[Span] = None,
         complement: t.Optional[Span] = None,
-        adverbials: t.List[Span] = [],
+        adverbials: t.List[Span] = None,
     ):
         """
         
@@ -124,6 +124,9 @@ class Clause:
         None.
 
         """
+        if adverbials is None:
+            adverbials = []
+
         self.subject = subject
         self.verb = verb
         self.indirect_object = indirect_object

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -407,6 +407,13 @@ def _get_subject(verb):
     return None
 
 
+def _find_matching_child(root, allowed_types):
+    for c in root.children:
+        if c.dep_ in allowed_types:
+            return extract_span_from_entity(c)
+    return None
+
+
 def extract_clauses(span):
     clauses = []
 
@@ -426,29 +433,10 @@ def extract_clauses(span):
                 clause = Clause(subject=subject, complement=comp)
                 clauses.append(clause)
 
-        # 1.c. find indirect object
-        iob = None
-        for c in verb.root.children:
-            if c.dep_ == "dative":
-                iob = extract_span_from_entity(c)
-
-        # 1.d. find direct object
-        dob = None
-        for c in verb.root.children:
-            if c.dep_ == "dobj":
-                dob = extract_span_from_entity(c)
-
-        # 1.e. find complements
-        comp = None
-        for c in verb.root.children:
-            if c.dep_ in ["ccomp", "acomp", "xcomp", "attr"]:
-                comp = extract_span_from_entity(c)
-
-        # 1.f. find adverbials
-        adv = []
-        for c in verb.root.children:
-            if c.dep_ in ["prep", "advmod", "agent"]:
-                adv.append(extract_span_from_entity(c))
+        iob = _find_matching_child(verb.root, ["dative"])
+        dob = _find_matching_child(verb.root, ["dobj"])
+        comp = _find_matching_child(verb.root, ["ccomp", "acomp", "xcomp", "attr"])
+        adv = [extract_span_from_entity(c) for c in verb.root.children if c.dep_ in ("prep", "advmod", "agent")]
 
         clause = Clause(
             subject=subject, verb=verb, indirect_object=iob, direct_object=dob, complement=comp, adverbials=adv)

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -244,10 +244,10 @@ class Clause:
 
         propositions = []
 
-        subjects = extract_ccs_from_token(self.subject.root)
-        direct_objects = extract_ccs_from_token(self.direct_object.root)
-        indirect_objects = extract_ccs_from_token(self.indirect_object.root)
-        complements = extract_ccs_from_token(self.complement.root)
+        subjects = extract_ccs_from_token_at_root(self.subject)
+        direct_objects = extract_ccs_from_token_at_root(self.direct_object)
+        indirect_objects = extract_ccs_from_token_at_root(self.indirect_object)
+        complements = extract_ccs_from_token_at_root(self.complement)
         verbs = [self.verb] if self.verb else []
 
         for subj in subjects:
@@ -458,10 +458,13 @@ def extract_ccs_from_entity(token):
             entities += extract_ccs_from_entity(c)
     return entities
 
+def extract_ccs_from_token_at_root(span):
+    if span is None:
+        return []
+    else:
+        return extract_ccs_from_token(span.root)
 
 def extract_ccs_from_token(token):
-    if token is None:
-        return []
     if token.pos_ in ["NOUN", "PROPN", "ADJ"]:
         children = sorted(
             [token]

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -110,9 +110,9 @@ class Clause:
             Subject.
         verb : Span
             Verb.
-        indirect_object : Span, optional
+        has_indirect_object : Span, optional
             Indirect object, The default is None.
-        direct_object : Span, optional
+        has_direct_object : Span, optional
             Direct object. The default is None.
         complement : Span, optional
             Complement. The default is None.
@@ -136,57 +136,57 @@ class Clause:
 
         self.doc = self.subject.doc
 
-        complementP = self.complement is not None
-        adverbialP = len(self.adverbials) > 0
-        ext_copular = (
-                self.verb is not None and self.verb.root.lemma_ in dictionary["ext_copular"]
+        has_verb = self.verb is not None
+        has_complement = self.complement is not None
+        has_adverbial = len(self.adverbials) > 0
+        has_ext_copular_verb = (
+                has_verb and self.verb.root.lemma_ in dictionary["ext_copular"]
         )
-        non_ext_copular = (
-                self.verb is not None and self.verb.root.lemma_ in dictionary["non_ext_copular"]
+        has_non_ext_copular_verb = (
+                has_verb and self.verb.root.lemma_ in dictionary["non_ext_copular"]
         )
         conservative = MOD_CONSERVATIVE
-        direct_object = self.direct_object is not None
-        indirect_object = self.indirect_object is not None
-        objectP = direct_object or indirect_object
+        has_direct_object = self.direct_object is not None
+        has_indirect_object = self.indirect_object is not None
+        has_object = has_direct_object or has_indirect_object
         complex_transitive = (
-                self.verb is not None
-                and self.verb.root.lemma_ in dictionary["complex_transitive"]
+                has_verb and self.verb.root.lemma_ in dictionary["complex_transitive"]
         )
 
         self.type = "undefined"
 
-        if self.verb is None:
+        if not has_verb:
             self.type = "SVC"
             return
-        if all([not objectP, complementP]):
+        if all([not has_object, has_complement]):
             self.type = "SVC"
-        if all([not objectP, not complementP, not adverbialP]):
+        if all([not has_object, not has_complement, not has_adverbial]):
             self.type = "SV"
-        if all([not objectP, not complementP, adverbialP, non_ext_copular]):
+        if all([not has_object, not has_complement, has_adverbial, has_non_ext_copular_verb]):
             self.type = "SV"
         if all(
-            [not objectP, not complementP, adverbialP, not non_ext_copular, ext_copular]
+            [not has_object, not has_complement, has_adverbial, not has_non_ext_copular_verb, has_ext_copular_verb]
         ):
             self.type = "SVA"
         if all(
             [
-                not objectP,
-                not complementP,
-                adverbialP,
-                not non_ext_copular,
-                not ext_copular,
+                not has_object,
+                not has_complement,
+                has_adverbial,
+                not has_non_ext_copular_verb,
+                not has_ext_copular_verb,
             ]
         ):
             if conservative:
                 self.type = "SVA"
             else:
                 self.type = "SV"
-        if all([objectP, direct_object, indirect_object]):
+        if all([has_object, has_direct_object, has_indirect_object]):
             self.type = "SVOO"
-        if all([objectP, not (direct_object and indirect_object)]):
-            if complementP:
+        if all([has_object, not (has_direct_object and has_indirect_object)]):
+            if has_complement:
                 self.type = "SVOC"
-            elif not (adverbialP and direct_object):
+            elif not (has_adverbial and has_direct_object):
                 self.type = "SVO"
             elif complex_transitive:
                 self.type = "SVOA"

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -259,7 +259,7 @@ class Clause:
             for verb in verbs:
                 prop = [subj, verb]
                 if self.type in ["SV", "SVA"]:
-                    if len(self.adverbials) > 0:
+                    if self.adverbials:
                         for a in self.adverbials:
                             propositions.append(tuple(prop + [a]))
                         propositions.append(tuple(prop + self.adverbials))
@@ -273,31 +273,29 @@ class Clause:
                 elif self.type == "SVO":
                     for obj in direct_objects + indirect_objects:
                         propositions.append((subj, verb, obj))
-                        if len(self.adverbials) > 0:
-                            for a in self.adverbials:
-                                propositions.append((subj, verb, obj, a))
+                        for a in self.adverbials:
+                            propositions.append((subj, verb, obj, a))
                 elif self.type == "SVOA":
                     for obj in direct_objects:
-                        if len(self.adverbials) > 0:
+                        if self.adverbials:
                             for a in self.adverbials:
                                 propositions.append(tuple(prop + [obj, a]))
                             propositions.append(tuple(prop + [obj] + self.adverbials))
 
                 elif self.type == "SVOC":
                     for obj in indirect_objects + direct_objects:
-                        if len(complements) > 0:
+                        if complements:
                             for c in complements:
                                 propositions.append(tuple(prop + [obj, c]))
                             propositions.append(tuple(prop + [obj] + complements))
                 elif self.type == "SVC":
-                    if len(complements) > 0:
+                    if complements:
                         for c in complements:
                             propositions.append(tuple(prop + [c]))
                         propositions.append(tuple(prop + complements))
 
         # Remove doubles
-        if len(propositions) > 0:
-            propositions = list(set(propositions))
+        propositions = list(set(propositions))
 
         # Convert to text if `as_text' is set.
         if as_text:

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -423,7 +423,7 @@ def extract_clauses(span):
         for c in subject.root.children:
             if c.dep_ in ["appos"]:
                 comp = extract_span_from_entity(c)
-                clause = Clause(subject, None, [], [], comp, [])
+                clause = Clause(subject=subject, complement=comp)
                 clauses.append(clause)
 
         # 1.c. find indirect object
@@ -450,7 +450,8 @@ def extract_clauses(span):
             if c.dep_ in ["prep", "advmod", "agent"]:
                 adv.append(extract_span_from_entity(c))
 
-        clause = Clause(subject, verb, iob, dob, comp, adv)
+        clause = Clause(
+            subject=subject, verb=verb, indirect_object=iob, direct_object=dob, complement=comp, adverbials=adv)
         clauses.append(clause)
     return clauses
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -255,6 +255,7 @@ class Clause:
                 for c in complements:
                     propositions.append((subj, "is", c))
                 propositions.append((subj, "is") + tuple(complements))
+
             for verb in verbs:
                 prop = [subj, verb]
                 if self.type in ["SV", "SVA"]:
@@ -265,30 +266,30 @@ class Clause:
                     else:
                         propositions.append(tuple(prop))
 
-                elif self.type in ["SVOO"]:
+                elif self.type == "SVOO":
                     for iobj in indirect_objects:
                         for dobj in direct_objects:
                             propositions.append((subj, verb, iobj, dobj))
-                elif self.type in ["SVO"]:
+                elif self.type == "SVO":
                     for obj in direct_objects + indirect_objects:
                         propositions.append((subj, verb, obj))
                         if len(self.adverbials) > 0:
                             for a in self.adverbials:
                                 propositions.append((subj, verb, obj, a))
-                elif self.type in ["SVOA"]:
+                elif self.type == "SVOA":
                     for obj in direct_objects:
                         if len(self.adverbials) > 0:
                             for a in self.adverbials:
                                 propositions.append(tuple(prop + [obj, a]))
                             propositions.append(tuple(prop + [obj] + self.adverbials))
 
-                elif self.type in ["SVOC"]:
+                elif self.type == "SVOC":
                     for obj in indirect_objects + direct_objects:
                         if len(complements) > 0:
                             for c in complements:
                                 propositions.append(tuple(prop + [obj, c]))
                             propositions.append(tuple(prop + [obj] + complements))
-                elif self.type in ["SVC"]:
+                elif self.type == "SVC":
                     if len(complements) > 0:
                         for c in complements:
                             propositions.append(tuple(prop + [c]))

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -245,16 +245,16 @@ class Clause:
         propositions = []
 
         subjects = extract_ccs_from_token(self.subject.root)
-        iobjs = extract_ccs_from_token(self.indirect_object.root)
-        dobjs = extract_ccs_from_token(self.direct_object.root)
-        comps = extract_ccs_from_token(self.complement.root)
+        direct_objects = extract_ccs_from_token(self.direct_object.root)
+        indirect_objects = extract_ccs_from_token(self.indirect_object.root)
+        complements = extract_ccs_from_token(self.complement.root)
         verbs = [self.verb] if self.verb else []
 
         for subj in subjects:
-            if comps and not verbs:
-                for c in comps:
+            if complements and not verbs:
+                for c in complements:
                     propositions.append((subj, "is", c))
-                propositions.append((subj, "is") + tuple(comps))
+                propositions.append((subj, "is") + tuple(complements))
             for verb in verbs:
                 prop = [subj, verb]
                 if self.type in ["SV", "SVA"]:
@@ -266,33 +266,33 @@ class Clause:
                         propositions.append(tuple(prop))
 
                 elif self.type in ["SVOO"]:
-                    for iobj in iobjs:
-                        for dobj in dobjs:
+                    for iobj in indirect_objects:
+                        for dobj in direct_objects:
                             propositions.append((subj, verb, iobj, dobj))
                 elif self.type in ["SVO"]:
-                    for obj in dobjs + iobjs:
+                    for obj in direct_objects + indirect_objects:
                         propositions.append((subj, verb, obj))
                         if len(self.adverbials) > 0:
                             for a in self.adverbials:
                                 propositions.append((subj, verb, obj, a))
                 elif self.type in ["SVOA"]:
-                    for obj in dobjs:
+                    for obj in direct_objects:
                         if len(self.adverbials) > 0:
                             for a in self.adverbials:
                                 propositions.append(tuple(prop + [obj, a]))
                             propositions.append(tuple(prop + [obj] + self.adverbials))
 
                 elif self.type in ["SVOC"]:
-                    for obj in iobjs + dobjs:
-                        if len(comps) > 0:
-                            for c in comps:
+                    for obj in indirect_objects + direct_objects:
+                        if len(complements) > 0:
+                            for c in complements:
                                 propositions.append(tuple(prop + [obj, c]))
-                            propositions.append(tuple(prop + [obj] + comps))
+                            propositions.append(tuple(prop + [obj] + complements))
                 elif self.type in ["SVC"]:
-                    if len(comps) > 0:
-                        for c in comps:
+                    if len(complements) > 0:
+                        for c in complements:
                             propositions.append(tuple(prop + [c]))
-                        propositions.append(tuple(prop + comps))
+                        propositions.append(tuple(prop + complements))
 
         # Remove doubles
         if len(propositions) > 0:

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -11,7 +11,7 @@ Clausie as a spacy library
 import spacy
 import lemminflect
 import logging
-import typing as t
+import typing
 
 from spacy.tokens import Span, Doc
 from spacy.matcher import Matcher
@@ -94,12 +94,12 @@ rarely""".split(),
 class Clause:
     def __init__(
             self,
-            subject: t.Optional[Span] = None,
-            verb: t.Optional[Span] = None,
-            indirect_object: t.Optional[Span] = None,
-            direct_object: t.Optional[Span] = None,
-            complement: t.Optional[Span] = None,
-            adverbials: t.List[Span] = None,
+            subject: typing.Optional[Span] = None,
+            verb: typing.Optional[Span] = None,
+            indirect_object: typing.Optional[Span] = None,
+            direct_object: typing.Optional[Span] = None,
+            complement: typing.Optional[Span] = None,
+            adverbials: typing.List[Span] = None,
     ):
         """
         
@@ -110,9 +110,9 @@ class Clause:
             Subject.
         verb : Span
             Verb.
-        has_indirect_object : Span, optional
+        indirect_object : Span, optional
             Indirect object, The default is None.
-        has_direct_object : Span, optional
+        direct_object : Span, optional
             Direct object. The default is None.
         complement : Span, optional
             Complement. The default is None.
@@ -324,11 +324,9 @@ class Clause:
                 for p in propositions
             ]
 
-            if capitalize:
-                # Capitalize and add a full stop.
-                return [text.capitalize() + "." for text in texts]
-            else:
-                return texts
+            if capitalize:  # Capitalize and add a full stop.
+                texts = [text.capitalize() + "." for text in texts]
+            return texts
 
         return propositions
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -93,13 +93,13 @@ rarely""".split(),
 
 class Clause:
     def __init__(
-        self,
-        subject: t.Optional[Span] = None,
-        verb: t.Optional[Span] = None,
-        indirect_object: t.Optional[Span] = None,
-        direct_object: t.Optional[Span] = None,
-        complement: t.Optional[Span] = None,
-        adverbials: t.List[Span] = None,
+            self,
+            subject: t.Optional[Span] = None,
+            verb: t.Optional[Span] = None,
+            indirect_object: t.Optional[Span] = None,
+            direct_object: t.Optional[Span] = None,
+            complement: t.Optional[Span] = None,
+            adverbials: t.List[Span] = None,
     ):
         """
         
@@ -231,7 +231,8 @@ class Clause:
 
     def __repr__(self):
         return "<{}, {}, {}, {}, {}, {}, {}>".format(
-            self.type, self.subject, self.verb, self.indirect_object, self.direct_object, self.complement, self.adverbials
+            self.type, self.subject, self.verb, self.indirect_object, self.direct_object, self.complement,
+            self.adverbials
         )
 
     def to_propositions(self, as_text: bool = False, inflect: str = "VBD", capitalize: bool = False):
@@ -243,30 +244,12 @@ class Clause:
 
         propositions = []
 
-        if self.subject:
-            subjects = extract_ccs_from_token(self.subject.root)
-        else:
-            subjects = []
+        subjects = extract_ccs_from_token(self.subject.root)
+        iobjs = extract_ccs_from_token(self.indirect_object.root)
+        dobjs = extract_ccs_from_token(self.direct_object.root)
+        comps = extract_ccs_from_token(self.complement.root)
+        verbs = [self.verb] if self.verb else []
 
-        if self.verb:
-            verbs = [self.verb]
-        else:
-            verbs = []
-
-        if self.indirect_object:
-            iobjs = extract_ccs_from_token(self.indirect_object.root)
-        else:
-            iobjs = []
-
-        if self.direct_object:
-            dobjs = extract_ccs_from_token(self.direct_object.root)
-        else:
-            dobjs = []
-
-        if self.complement:
-            comps = extract_ccs_from_token(self.complement.root)
-        else:
-            comps = []
 
         for subj in subjects:
             if len(verbs) == 0:
@@ -328,12 +311,12 @@ class Clause:
                                     t._.inflect(inflect)
                                 )  # Inflect the verb according to the `inflect` flag
                                 if t.pos_ in ["VERB"]  # If t is a verb
-                                and "AUX"
-                                not in [
-                                    tt.pos_ for tt in t.lefts
-                                ]  # t is not preceded by an auxiliary verb (e.g. `the birds were ailing`)
-                                and t.dep_ not in ['pcomp'] # t `deamed of becoming a dancer`
-                                and inflect  # and the `inflect' flag is set
+                                   and "AUX"
+                                   not in [
+                                       tt.pos_ for tt in t.lefts
+                                   ]  # t is not preceded by an auxiliary verb (e.g. `the birds were ailing`)
+                                   and t.dep_ not in ['pcomp']  # t `deamed of becoming a dancer`
+                                   and inflect  # and the `inflect' flag is set
                                 else str(t)
                                 for t in s
                             ]
@@ -478,6 +461,8 @@ def extract_ccs_from_entity(token):
 
 
 def extract_ccs_from_token(token):
+    if token is None:
+        return []
     if token.pos_ in ["NOUN", "PROPN", "ADJ"]:
         children = sorted(
             [token]
@@ -521,7 +506,7 @@ if __name__ == "__main__":
     add_to_pipe(nlp)
 
     doc = nlp(
-        #"Chester is a banker by trade, but is dreaming of becoming a great dancer."
+        # "Chester is a banker by trade, but is dreaming of becoming a great dancer."
         " A cat , hearing that the birds in a certain aviary were ailing dressed himself up as a physician , and , taking his cane and a bag of instruments becoming his profession , went to call on them ."
     )
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -240,7 +240,7 @@ class Clause:
         if inflect and not as_text:
             logging.warning("`inflect' argument is ignored when `as_text==False'")
         if capitalize and not as_text:
-            logging.warning("`capitalize' agrument is ignored when `as_text==False'")
+            logging.warning("`capitalize' argument is ignored when `as_text==False'")
 
         propositions = []
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -349,9 +349,7 @@ def _convert_clauses_to_text(propositions, inflect, capitalize):
 
     return proposition_texts
 
-
-def extract_clauses(span):
-    clauses = []
+def _get_verb_matches(span):
     # 1. Find verb phrases in the span
     # (see mdmjsh answer here: https://stackoverflow.com/questions/47856247/extract-verb-phrases-using-spacy)
 
@@ -362,7 +360,12 @@ def extract_clauses(span):
     verb_matcher.add("Auxiliary verb phrase", None, [{"POS": "AUX"}])
     verb_matcher.add("Verb phrase", None, [{"POS": "VERB"}])
 
-    matches = verb_matcher(span)
+    return verb_matcher(span)
+
+
+def extract_clauses(span):
+    clauses = []
+    matches = _get_verb_matches(span)
 
     # Filter matches (e.g. do not have both "has won" and "won" in verbs)
     verb_chunks = []

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -93,29 +93,29 @@ rarely""".split(),
 class Clause:
     def __init__(
         self,
-        S: Span = None,
-        V: Span = None,
-        I: Span = None,
-        O: Span = None,
-        C: Span = None,
-        A: list = [],
+        subject: Span = None,
+        verb: Span = None,
+        indirect_object: Span = None,
+        direct_object: Span = None,
+        complement: Span = None,
+        adverbials: list = [],
     ):
         """
         
 
         Parameters
         ----------
-        S : Span
+        subject : Span
             Subject.
-        V : Span
+        verb : Span
             Verb.
-        I : Span, optional
+        indirect_object : Span, optional
             Indirect object, The default is None.
-        O : Span, optional
+        direct_object : Span, optional
             Direct object. The default is None.
-        C : Span, optional
+        complement : Span, optional
             Complement. The default is None.
-        A : list, optional
+        adverbials : list, optional
             List of adverbials. The default is [].
 
         Returns
@@ -123,35 +123,35 @@ class Clause:
         None.
 
         """
-        self.S = S
-        self.V = V
-        self.I = I
-        self.O = O
-        self.C = C
-        self.A = A
+        self.subject = subject
+        self.verb = verb
+        self.indirect_object = indirect_object
+        self.direct_object = direct_object
+        self.complement = complement
+        self.adverbials = adverbials
 
-        self.doc = self.S.doc
+        self.doc = self.subject.doc
 
-        complementP = self.C is not None
-        adverbialP = len(self.A) > 0
+        complementP = self.complement is not None
+        adverbialP = len(self.adverbials) > 0
         ext_copular = (
-            self.V is not None and self.V.root.lemma_ in dictionary["ext_copular"]
+                self.verb is not None and self.verb.root.lemma_ in dictionary["ext_copular"]
         )
         non_ext_copular = (
-            self.V is not None and self.V.root.lemma_ in dictionary["non_ext_copular"]
+                self.verb is not None and self.verb.root.lemma_ in dictionary["non_ext_copular"]
         )
         conservative = MOD_CONSERVATIVE
-        direct_object = self.O is not None
-        indirect_object = self.I is not None
+        direct_object = self.direct_object is not None
+        indirect_object = self.indirect_object is not None
         objectP = direct_object or indirect_object
         complex_transitive = (
-            self.V is not None
-            and self.V.root.lemma_ in dictionary["complex_transitive"]
+                self.verb is not None
+                and self.verb.root.lemma_ in dictionary["complex_transitive"]
         )
 
         self.type = "undefined"
 
-        if self.V is None:
+        if self.verb is None:
             self.type = "SVC"
             return
         if all([not objectP, complementP]):
@@ -194,7 +194,7 @@ class Clause:
 
     def __repr__(self):
         return "<{}, {}, {}, {}, {}, {}, {}>".format(
-            self.type, self.S, self.V, self.I, self.O, self.C, self.A
+            self.type, self.subject, self.verb, self.indirect_object, self.direct_object, self.complement, self.adverbials
         )
 
     def to_propositions(self, as_text: bool = False, inflect: str = "VBD", capitalize: bool = False):
@@ -206,28 +206,28 @@ class Clause:
 
         propositions = []
 
-        if self.S:
-            subjects = extract_ccs_from_token(self.S.root)
+        if self.subject:
+            subjects = extract_ccs_from_token(self.subject.root)
         else:
             subjects = []
 
-        if self.V:
-            verbs = [self.V]
+        if self.verb:
+            verbs = [self.verb]
         else:
             verbs = []
 
-        if self.I:
-            iobjs = extract_ccs_from_token(self.I.root)
+        if self.indirect_object:
+            iobjs = extract_ccs_from_token(self.indirect_object.root)
         else:
             iobjs = []
 
-        if self.O:
-            dobjs = extract_ccs_from_token(self.O.root)
+        if self.direct_object:
+            dobjs = extract_ccs_from_token(self.direct_object.root)
         else:
             dobjs = []
 
-        if self.C:
-            comps = extract_ccs_from_token(self.C.root)
+        if self.complement:
+            comps = extract_ccs_from_token(self.complement.root)
         else:
             comps = []
 
@@ -240,10 +240,10 @@ class Clause:
             for verb in verbs:
                 prop = [subj, verb]
                 if self.type in ["SV", "SVA"]:
-                    if len(self.A) > 0:
-                        for a in self.A:
+                    if len(self.adverbials) > 0:
+                        for a in self.adverbials:
                             propositions.append(tuple(prop + [a]))
-                        propositions.append(tuple(prop + self.A))
+                        propositions.append(tuple(prop + self.adverbials))
                     else:
                         propositions.append(tuple(prop))
 
@@ -254,15 +254,15 @@ class Clause:
                 elif self.type in ["SVO"]:
                     for obj in dobjs + iobjs:
                         propositions.append((subj, verb, obj))
-                        if len(self.A) > 0:
-                            for a in self.A:
+                        if len(self.adverbials) > 0:
+                            for a in self.adverbials:
                                 propositions.append((subj, verb, obj, a))
                 elif self.type in ["SVOA"]:
                     for obj in dobjs:
-                        if len(self.A) > 0:
-                            for a in self.A:
+                        if len(self.adverbials) > 0:
+                            for a in self.adverbials:
                                 propositions.append(tuple(prop + [obj, a]))
-                            propositions.append(tuple(prop + [obj] + self.A))
+                            propositions.append(tuple(prop + [obj] + self.adverbials))
 
                 elif self.type in ["SVOC"]:
                     for obj in iobjs + dobjs:

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -250,13 +250,11 @@ class Clause:
         comps = extract_ccs_from_token(self.complement.root)
         verbs = [self.verb] if self.verb else []
 
-
         for subj in subjects:
-            if len(verbs) == 0:
-                if len(comps) > 0:
-                    for c in comps:
-                        propositions.append((subj, "is", c))
-                    propositions.append((subj, "is") + tuple(comps))
+            if comps and not verbs:
+                for c in comps:
+                    propositions.append((subj, "is", c))
+                propositions.append((subj, "is") + tuple(comps))
             for verb in verbs:
                 prop = [subj, verb]
                 if self.type in ["SV", "SVA"]:

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -237,9 +237,9 @@ class Clause:
     def to_propositions(self, as_text: bool = False, inflect: str = "VBD", capitalize: bool = False):
 
         if inflect and not as_text:
-            logging.warn("`inflect' argument is ignored when `as_text==False'")
+            logging.warning("`inflect' argument is ignored when `as_text==False'")
         if capitalize and not as_text:
-            logging.warn("`capitalize' agrument is ignored when `as_text==False'")
+            logging.warning("`capitalize' agrument is ignored when `as_text==False'")
 
         propositions = []
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -429,17 +429,24 @@ def extract_clauses(span):
         # <AE, is, a scientist>
         for c in subject.root.children:
             if c.dep_ == "appos":
-                comp = extract_span_from_entity(c)
-                clause = Clause(subject=subject, complement=comp)
+                complement = extract_span_from_entity(c)
+                clause = Clause(subject=subject, complement=complement)
                 clauses.append(clause)
 
-        iob = _find_matching_child(verb.root, ["dative"])
-        dob = _find_matching_child(verb.root, ["dobj"])
-        comp = _find_matching_child(verb.root, ["ccomp", "acomp", "xcomp", "attr"])
-        adv = [extract_span_from_entity(c) for c in verb.root.children if c.dep_ in ("prep", "advmod", "agent")]
+        indirect_object = _find_matching_child(verb.root, ["dative"])
+        direct_object = _find_matching_child(verb.root, ["dobj"])
+        complement = _find_matching_child(verb.root, ["ccomp", "acomp", "xcomp", "attr"])
+        adverbials = [extract_span_from_entity(c)
+                      for c in verb.root.children
+                      if c.dep_ in ("prep", "advmod", "agent")]
 
         clause = Clause(
-            subject=subject, verb=verb, indirect_object=iob, direct_object=dob, complement=comp, adverbials=adv)
+            subject=subject,
+            verb=verb,
+            indirect_object=indirect_object,
+            direct_object=direct_object,
+            complement=complement,
+            adverbials=adverbials)
         clauses.append(clause)
     return clauses
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -303,12 +303,13 @@ class Clause:
         return propositions
 
 
-def inflect_token(token):
-    if (token.pos_ == "VERB"
+def inflect_token(token, inflect):
+    if (inflect
+            and token.pos_ == "VERB"
             and "AUX" not in [tt.pos_ for tt in token.lefts]
             # t is not preceded by an auxiliary verb (e.g. `the birds were ailing`)
             and token.dep_ != 'pcomp'):  # t `dreamed of becoming a dancer`
-        return str(token._.inflect(True))
+        return str(token._.inflect(inflect))
     else:
         return str(token)
 
@@ -321,10 +322,7 @@ def _convert_clauses_to_text(propositions, inflect, capitalize):
 
             token_texts = []
             for token in span:
-                if inflect:
-                    token_texts.append(inflect_token(token))
-                else:
-                    token_texts.append(str(token))
+                token_texts.append(inflect_token(token, inflect))
 
             span_texts.append(" ".join(token_texts))
         proposition_texts.append(" ".join(span_texts))

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -11,6 +11,7 @@ Clausie as a spacy library
 import spacy
 import lemminflect
 import logging
+import typing as t
 
 from spacy.tokens import Span, Doc
 from spacy.matcher import Matcher
@@ -93,12 +94,12 @@ rarely""".split(),
 class Clause:
     def __init__(
         self,
-        subject: Span = None,
-        verb: Span = None,
-        indirect_object: Span = None,
-        direct_object: Span = None,
-        complement: Span = None,
-        adverbials: list = [],
+        subject: t.Optional[Span] = None,
+        verb: t.Optional[Span] = None,
+        indirect_object: t.Optional[Span] = None,
+        direct_object: t.Optional[Span] = None,
+        complement: t.Optional[Span] = None,
+        adverbials: t.List[Span] = [],
     ):
         """
         
@@ -311,7 +312,7 @@ class Clause:
                 # Capitalize and add a full stop.
                 return [text.capitalize() + "." for text in texts]
             else:
-                return texts       
+                return texts
 
         return propositions
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     version="0.0.1.990",
     packages=find_packages(),
     # scripts=['claucy/__init__.py', 'clausiepy/__init__.py'],
-    install_requires=["spacy>=2.3.0"],
+    install_requires=["spacy>=2.3.0", "lemminflect"],
     test_suite="tests.test_suite",
     author="Emmanouil Theofanis Chourdakis",
     author_email="etchourdakis@gmail.com",


### PR DESCRIPTION
Expand shortened part of speech variable names in most places for readability. Particularly with autocompletion it's usually the best practice.

Restructure several parts to simplify. Original or close-to-original code is left commented in. Tests and manual tests pass but I can't guarantee all behaviour is identical.

Other minor changes listed in commit messages.

This is separated into many small commits to hopefully make it easy to revert changes you don't like.