### PR TITLE
Guard against infinite recursion

### DIFF
--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -389,8 +389,8 @@ def _get_subject(verb):
                 return subject
 
             if c.dep_ in ["acl", "advcl"]:
-                subject = extract_span_from_entity(find_verb_subject(c))
-                return subject
+                subject = find_verb_subject(c)
+                return extract_span_from_entity(subject) if subject else None
 
         # Break cycles
         if root == verb.root.head:
@@ -523,7 +523,7 @@ def find_verb_subject(v):
     for c in v.children:
         if c.dep_ in ["nsubj", "nsubjpass", "nsubj:pass"]:
             return c
-        elif c.dep_ in ["advcl", "acl"]:
+        elif c.dep_ in ["advcl", "acl"] and v.head.dep_ != "ROOT":
             return find_verb_subject(v.head)
 
 

--- a/claucy/claucy.py
+++ b/claucy/claucy.py
@@ -382,7 +382,7 @@ def _get_subject(verb):
             return subject
 
     root = verb.root
-    while root.dep_ in ["conj", "cc", "advcl", "acl", "ccomp"]:
+    while root.dep_ in ["conj", "cc", "advcl", "acl", "ccomp", "ROOT"]:
         for c in root.children:
             if c.dep_ in ["nsubj", "nsubjpass"]:
                 subject = extract_span_from_entity(c)
@@ -516,7 +516,8 @@ def find_verb_subject(v):
     """
     if v.dep_ in ["nsubj", "nsubjpass", "nsubj:pass"]:
         return v
-    elif v.dep_ in ["advcl", "acl"]:
+    # guard against infinite recursion on root token
+    elif v.dep_ in ["advcl", "acl"] and v.head.dep_ != "ROOT":
         return find_verb_subject(v.head)
 
     for c in v.children:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     version="0.0.1.991",
     packages=find_packages(),
     # scripts=['claucy/__init__.py', 'clausiepy/__init__.py'],
-    install_requires=["spacy>=2.3.0", "lemminflecti>=0.2.1"],
+    install_requires=["spacy>=2.3.0", "lemminflect>=0.2.1"],
     test_suite="tests.test_suite",
     author="Emmanouil Theofanis Chourdakis",
     author_email="etchourdakis@gmail.com",


### PR DESCRIPTION
Added logic to `_get_subject` and `find_verb_subject` to avoid infinite recursion error on root tokens and match the output for the complex sentence example in the readme.

Tested with `spacy==2.3.2` and `en_core_web_lg-2.3.1`.